### PR TITLE
Use dedicated renderers

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,15 +61,15 @@
 
 #if defined(ARDUINO_LOLIN_S2_MINI)
 	#ifdef NEOPIXEL_RGBW
-		#define LED_DRIVER NeoPixelBus<NeoGrbwFeature, NeoEsp32I2s0800KbpsMethod>
+		#define LED_DRIVER NeoPixelBus<NeoGrbwFeature, NeoEsp32I2s0Sk6812Method>
 	#elif NEOPIXEL_RGB
-		#define LED_DRIVER NeoPixelBus<NeoGrbFeature, NeoEsp32I2s0800KbpsMethod>
+		#define LED_DRIVER NeoPixelBus<NeoGrbFeature, NeoEsp32I2s0Ws2812xMethod>
 	#endif
 #else
 	#ifdef NEOPIXEL_RGBW
-		#define LED_DRIVER NeoPixelBus<NeoGrbwFeature, NeoEsp32I2s1800KbpsMethod>
+		#define LED_DRIVER NeoPixelBus<NeoGrbwFeature, NeoEsp32I2s1Sk6812Method>
 	#elif NEOPIXEL_RGB
-		#define LED_DRIVER NeoPixelBus<NeoGrbFeature, NeoEsp32I2s1800KbpsMethod>
+		#define LED_DRIVER NeoPixelBus<NeoGrbFeature, NeoEsp32I2s1Ws2812xMethod>
 	#endif
 #endif
 
@@ -88,9 +88,9 @@
 #if defined(SECOND_SEGMENT_START_INDEX)
 	#if defined(ARDUINO_LOLIN_S2_MINI)
 		#ifdef NEOPIXEL_RGBW
-			#define LED_DRIVER2 NeoPixelBus<NeoGrbwFeature, NeoEsp32Rmt0800KbpsMethod>
+			#define LED_DRIVER2 NeoPixelBus<NeoGrbwFeature, NeoEsp32Rmt0Sk6812Method>
 		#elif NEOPIXEL_RGB
-			#define LED_DRIVER2 NeoPixelBus<NeoGrbFeature, NeoEsp32Rmt0800KbpsMethod>
+			#define LED_DRIVER2 NeoPixelBus<NeoGrbFeature, NeoEsp32Rmt0Ws2812xMethod>
 		#elif SPILED_APA102
 			#define LED_DRIVER2 NeoPixelBus<DotStarBgrFeature, DotStarEsp32DmaHspiMethod>
 		#elif SPILED_WS2801
@@ -98,9 +98,9 @@
 		#endif
 	#else
 		#ifdef NEOPIXEL_RGBW
-			#define LED_DRIVER2 NeoPixelBus<NeoGrbwFeature, NeoEsp32I2s0800KbpsMethod>
+			#define LED_DRIVER2 NeoPixelBus<NeoGrbwFeature, NeoEsp32I2s0Sk6812Method>
 		#elif NEOPIXEL_RGB
-			#define LED_DRIVER2 NeoPixelBus<NeoGrbFeature, NeoEsp32I2s0800KbpsMethod>
+			#define LED_DRIVER2 NeoPixelBus<NeoGrbFeature, NeoEsp32I2s0Ws2812xMethod>
 		#elif SPILED_APA102
 			#define LED_DRIVER2 NeoPixelBus<DotStarBgrFeature, DotStarEsp32DmaVspiMethod>
 		#elif SPILED_WS2801


### PR DESCRIPTION
For better compatibility, the common renderer has been replaced with dedicated ones: one for RGBW (sk6812) and the other for RGB (ws281x).
