### PR TITLE
Add factory firmware build and enable USB CDC on boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,16 @@ RGB to RGBW conversion is calibrated for the neutral white channel BTF SK6812 bu
 Why the data integrity check was introduced which causes incompatibility with other software? Because at 2Mb speed many chip-makers allow few percent error in the transmission. And we do not want to have any distracting flashes. Broken frames are abandon without showing them. At 100Hz for 250 leds approximately 1-5% of the frames are broken.
   
 # Flashing
-  
+
+There are two versions of the firmware. The 'factory' and the 'base' one. Factory firmware should be flashed to offset 0x0, base firmware to offset 0x10000.
+
 **ESP32-S2 Lolin mini:**
 
 Requires using `esptool.py` to flash the firmware e.g.  
 
 `esptool.py write_flash 0x10000 firmware_esp32_s2_mini_SK6812_RGBW_COLD.bin`
+or
+`esptool.py write_flash 0x0 firmware_esp32_s2_mini_SK6812_RGBW_COLD.factory.bin`
 
 Troubleshooting: ESP32-S2 Lolin mini recovery procedure.  
 1. Put the board into dfu mode using board buttons: press board `Rst` + `0` buttons, then release `Rst`, next release `0`  

--- a/README.md
+++ b/README.md
@@ -35,9 +35,8 @@ There are two versions of the firmware. The 'factory' and the 'base' one. Factor
 
 Requires using `esptool.py` to flash the firmware e.g.  
 
-`esptool.py write_flash 0x10000 firmware_esp32_s2_mini_SK6812_RGBW_COLD.bin`
-or
-`esptool.py write_flash 0x0 firmware_esp32_s2_mini_SK6812_RGBW_COLD.factory.bin`
+ - `esptool.py write_flash 0x10000 firmware_esp32_s2_mini_SK6812_RGBW_COLD.bin` or
+ - `esptool.py write_flash 0x0 firmware_esp32_s2_mini_SK6812_RGBW_COLD.factory.bin`
 
 Troubleshooting: ESP32-S2 Lolin mini recovery procedure.  
 1. Put the board into dfu mode using board buttons: press board `Rst` + `0` buttons, then release `Rst`, next release `0`  

--- a/extra_script.py
+++ b/extra_script.py
@@ -1,13 +1,72 @@
 Import("env")
+platform = env.PioPlatform()
+
+import sys
+from os.path import join
 from pathlib import Path
 import shutil
 
+sys.path.append(join(platform.get_package_dir("tool-esptoolpy")))
+import esptool
 
 def post_program_action(source, target, env):
     program_path = target[0].get_abspath()
     path = Path(program_path)
     shutil.copy(program_path, path.parent.parent.absolute())
-env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", post_program_action)
 
+# Combine separate bin files with their respective offsets into a single file
+# This single file must then be flashed to an ESP32 node with 0 offset.
+# Copied from: https://github.com/letscontrolit/ESPEasy/blob/mega/tools/pio/post_esp32.py
+def esp32_create_combined_bin(source, target, env):
+    print("Generating combined binary for serial flashing")
+
+    # The offset from begin of the file where the app0 partition starts
+    # This is defined in the partition .csv file
+    app_offset = 0x10000
+
+    new_file_name = env.subst("$BUILD_DIR/${PROGNAME}.factory.bin")
+    sections = env.subst(env.get("FLASH_EXTRA_IMAGES"))
+    firmware_name = env.subst("$BUILD_DIR/${PROGNAME}.bin")
+    chip = env.get("BOARD_MCU")
+    flash_size = env.BoardConfig().get("upload.flash_size")
+    flash_freq = env.BoardConfig().get("build.f_flash", '40m')
+    flash_freq = flash_freq.replace('000000L', 'm')
+    flash_mode = env.BoardConfig().get("build.flash_mode", "dio")
+    memory_type = env.BoardConfig().get("build.arduino.memory_type", "qio_qspi")
+    if flash_mode == "qio" or flash_mode == "qout":
+        flash_mode = "dio"
+    if memory_type == "opi_opi" or memory_type == "opi_qspi":
+        flash_mode = "dout"
+    cmd = [
+        "--chip",
+        chip,
+        "merge_bin",
+        "-o",
+        new_file_name,
+        "--flash_mode",
+        flash_mode,
+        "--flash_freq",
+        flash_freq,
+        "--flash_size",
+        flash_size,
+    ]
+
+    print("    Offset | File")
+    for section in sections:
+        sect_adr, sect_file = section.split(" ", 1)
+        print(f" -  {sect_adr} | {sect_file}")
+        cmd += [sect_adr, sect_file]
+
+    print(f" - {hex(app_offset)} | {firmware_name}")
+    cmd += [hex(app_offset), firmware_name]
+
+    print('Using esptool.py arguments: %s' % ' '.join(cmd))
+
+    esptool.main(cmd)
+    path = Path(new_file_name)
+    shutil.copy(new_file_name, path.parent.parent.absolute())
+
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", post_program_action)
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", esp32_create_combined_bin)
 env.Replace(PROGNAME="firmware_%s" % env.GetProjectOption("custom_prog_version"))
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,7 +24,6 @@ default_envs = SK6812_RGBW_COLD, SK6812_RGBW_NEUTRAL, WS281x_RGB, SPI_APA102_SK9
 framework = arduino
 extra_scripts = pre:extra_script.py
 build_flags = -DSERIALCOM_SPEED=2000000
-upload_speed = 921600
 
 ;==========================================================
 ; ESP32 board
@@ -83,15 +82,12 @@ test_ignore = ${esp32.test_ignore}
 ; ESP32-S2 board
 ;==========================================================
 [esp32_lolin_s2_mini]
-build_flags = -DARDUINO_USB_CDC_ON_BOOT ${env.build_flags}
-build_unflags = -DARDUINO_USB_MODE
 platform = espressif32@6.0.0
 lib_deps = https://github.com/awawa-dev/NeoPixelBus.git#HyperSerialESP32
 test_ignore = *
 
 [env:s2_mini_SK6812_RGBW_COLD]
-build_flags = -DNEOPIXEL_RGBW -DCOLD_WHITE -DDATA_PIN=2 ${esp32_lolin_s2_mini.build_flags}
-build_unflags = ${esp32_lolin_s2_mini.build_unflags}
+build_flags = -DNEOPIXEL_RGBW -DCOLD_WHITE -DDATA_PIN=2 ${env.build_flags}
 custom_prog_version = esp32_s2_mini_SK6812_RGBW_COLD
 
 board = lolin_s2_mini
@@ -101,8 +97,7 @@ lib_deps = ${esp32_lolin_s2_mini.lib_deps}
 test_ignore = ${esp32_lolin_s2_mini.test_ignore}
 
 [env:s2_mini_SK6812_RGBW_NEUTRAL]
-build_flags = -DNEOPIXEL_RGBW -DDATA_PIN=2 ${esp32_lolin_s2_mini.build_flags}
-build_unflags = ${esp32_lolin_s2_mini.build_unflags}
+build_flags = -DNEOPIXEL_RGBW -DDATA_PIN=2 ${env.build_flags}
 custom_prog_version = esp32_s2_mini_SK6812_RGBW_NEUTRAL
 
 board = lolin_s2_mini
@@ -112,8 +107,7 @@ lib_deps = ${esp32_lolin_s2_mini.lib_deps}
 test_ignore = ${esp32_lolin_s2_mini.test_ignore}
 
 [env:s2_mini_WS281x_RGB]
-build_flags = -DNEOPIXEL_RGB -DDATA_PIN=2 ${esp32_lolin_s2_mini.build_flags}
-build_unflags = ${esp32_lolin_s2_mini.build_unflags}
+build_flags = -DNEOPIXEL_RGB -DDATA_PIN=2 ${env.build_flags}
 custom_prog_version = esp32_s2_mini_WS281x_RGB
 
 board = lolin_s2_mini
@@ -123,8 +117,7 @@ lib_deps = ${esp32_lolin_s2_mini.lib_deps}
 test_ignore = ${esp32_lolin_s2_mini.test_ignore}
 
 [env:s2_mini_SPI_APA102_SK9822_HD107]
-build_flags = -DSPILED_APA102 -DDATA_PIN=2 -DCLOCK_PIN=4 ${esp32_lolin_s2_mini.build_flags}
-build_unflags = ${esp32_lolin_s2_mini.build_unflags}
+build_flags = -DSPILED_APA102 -DDATA_PIN=2 -DCLOCK_PIN=4 ${env.build_flags}
 custom_prog_version = esp32_s2_mini_SPI_APA102_SK9822_HD107
 
 board = lolin_s2_mini
@@ -134,8 +127,7 @@ lib_deps = ${esp32_lolin_s2_mini.lib_deps}
 test_ignore = ${esp32_lolin_s2_mini.test_ignore}
 
 [env:s2_mini_SPI_WS2801]
-build_flags = -DSPILED_WS2801 -DDATA_PIN=2 -DCLOCK_PIN=4 ${esp32_lolin_s2_mini.build_flags}
-build_unflags = ${esp32_lolin_s2_mini.build_unflags}
+build_flags = -DSPILED_WS2801 -DDATA_PIN=2 -DCLOCK_PIN=4 ${env.build_flags}
 custom_prog_version = esp32_s2_mini_SPI_WS2801
 
 board = lolin_s2_mini

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,6 +24,7 @@ default_envs = SK6812_RGBW_COLD, SK6812_RGBW_NEUTRAL, WS281x_RGB, SPI_APA102_SK9
 framework = arduino
 extra_scripts = pre:extra_script.py
 build_flags = -DSERIALCOM_SPEED=2000000
+upload_speed = 921600
 
 ;==========================================================
 ; ESP32 board
@@ -82,12 +83,15 @@ test_ignore = ${esp32.test_ignore}
 ; ESP32-S2 board
 ;==========================================================
 [esp32_lolin_s2_mini]
+build_flags = -DARDUINO_USB_CDC_ON_BOOT ${env.build_flags}
+build_unflags = -DARDUINO_USB_MODE
 platform = espressif32@6.0.0
 lib_deps = https://github.com/awawa-dev/NeoPixelBus.git#HyperSerialESP32
 test_ignore = *
 
 [env:s2_mini_SK6812_RGBW_COLD]
-build_flags = -DNEOPIXEL_RGBW -DCOLD_WHITE -DDATA_PIN=2 ${env.build_flags}
+build_flags = -DNEOPIXEL_RGBW -DCOLD_WHITE -DDATA_PIN=2 ${esp32_lolin_s2_mini.build_flags}
+build_unflags = ${esp32_lolin_s2_mini.build_unflags}
 custom_prog_version = esp32_s2_mini_SK6812_RGBW_COLD
 
 board = lolin_s2_mini
@@ -97,7 +101,8 @@ lib_deps = ${esp32_lolin_s2_mini.lib_deps}
 test_ignore = ${esp32_lolin_s2_mini.test_ignore}
 
 [env:s2_mini_SK6812_RGBW_NEUTRAL]
-build_flags = -DNEOPIXEL_RGBW -DDATA_PIN=2 ${env.build_flags}
+build_flags = -DNEOPIXEL_RGBW -DDATA_PIN=2 ${esp32_lolin_s2_mini.build_flags}
+build_unflags = ${esp32_lolin_s2_mini.build_unflags}
 custom_prog_version = esp32_s2_mini_SK6812_RGBW_NEUTRAL
 
 board = lolin_s2_mini
@@ -107,7 +112,8 @@ lib_deps = ${esp32_lolin_s2_mini.lib_deps}
 test_ignore = ${esp32_lolin_s2_mini.test_ignore}
 
 [env:s2_mini_WS281x_RGB]
-build_flags = -DNEOPIXEL_RGB -DDATA_PIN=2 ${env.build_flags}
+build_flags = -DNEOPIXEL_RGB -DDATA_PIN=2 ${esp32_lolin_s2_mini.build_flags}
+build_unflags = ${esp32_lolin_s2_mini.build_unflags}
 custom_prog_version = esp32_s2_mini_WS281x_RGB
 
 board = lolin_s2_mini
@@ -117,7 +123,8 @@ lib_deps = ${esp32_lolin_s2_mini.lib_deps}
 test_ignore = ${esp32_lolin_s2_mini.test_ignore}
 
 [env:s2_mini_SPI_APA102_SK9822_HD107]
-build_flags = -DSPILED_APA102 -DDATA_PIN=2 -DCLOCK_PIN=4 ${env.build_flags}
+build_flags = -DSPILED_APA102 -DDATA_PIN=2 -DCLOCK_PIN=4 ${esp32_lolin_s2_mini.build_flags}
+build_unflags = ${esp32_lolin_s2_mini.build_unflags}
 custom_prog_version = esp32_s2_mini_SPI_APA102_SK9822_HD107
 
 board = lolin_s2_mini
@@ -127,7 +134,8 @@ lib_deps = ${esp32_lolin_s2_mini.lib_deps}
 test_ignore = ${esp32_lolin_s2_mini.test_ignore}
 
 [env:s2_mini_SPI_WS2801]
-build_flags = -DSPILED_WS2801 -DDATA_PIN=2 -DCLOCK_PIN=4 ${env.build_flags}
+build_flags = -DSPILED_WS2801 -DDATA_PIN=2 -DCLOCK_PIN=4 ${esp32_lolin_s2_mini.build_flags}
+build_unflags = ${esp32_lolin_s2_mini.build_unflags}
 custom_prog_version = esp32_s2_mini_SPI_WS2801
 
 board = lolin_s2_mini


### PR DESCRIPTION
I flashed your firmware to the wrong offset 0x1000 instead if 0x10000. This lead to a "broken" board which refused to bring up USB on boot even when I flashed it later to the correct offset. To fix this I had to build factory image with ARDUINO_USB_CDC_ON_BOOT flag included in the build flags. This PR is based on this experience...

- For people wanting to do a clean-flash of their devices, there is now a factory image which should be flashed at the offset 0x0.
- The build flags were modified for ESP32-S2 board to add ARDUINO_USB_CDC_ON_BOOT. Without this flag my ESP32-S2 (lolin) board was not coming up with the USB interface.

Thank you for the great work on the HyperHDR.