### PR TITLE
implemented external LED power control

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,12 @@ Implementation example:
 
 ![HyperSPI](https://user-images.githubusercontent.com/85223482/222923979-f344349a-1f8b-4195-94ca-51721923359e.png)
 
-# External power control
+# External relay power control
 You can configure LED power pin in the `platformio.ini` to power off LEDs while not in use.
 Review the comments at the top of the file:
 * `LED_POWER_PIN` - This is the data pin external power control
 
-Note: For static color configuration this mechanism will turn off the LEDs. To counter this the refresh time must be set to a non zero value in HyperHDR - LED Hardware.
+Note: For static color configuration this mechanism will turn off the LEDs. To counter this enable "Continuous Output" in HyperHDR "Smoothing" module. For esp32 and relay control, you may want to disable the "Handshake" option in the Adalight HyperHDR driver to avoid the relay immediately shutting down when resetting the device while initializing the connection.
 
 # Some benchmark results
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ Implementation example:
 
 ![HyperSPI](https://user-images.githubusercontent.com/85223482/222923979-f344349a-1f8b-4195-94ca-51721923359e.png)
 
+# External power control
+You can configure LED power pin in the `platformio.ini` to power off LEDs while not in use.
+Review the comments at the top of the file:
+* `LED_POWER_PIN` - This is the data pin external power control
+
+Note: For static color configuration this mechanism will turn off the LEDs. To counter this the refresh time must be set to a non zero value in HyperHDR - LED Hardware.
+
 # Some benchmark results
 
 ESP32 MH-ET LIVE mini is capable of 4Mb serial port speed and ESP32-S2 lolin mini is capable of 5Mb. But to give equal chances for a single-segment mode all models were tested using the default speed of 2Mb which should saturate Neopixel data line. Parallel multi-segment mode uses the highest option available because communication performance is critical here.

--- a/include/main.h
+++ b/include/main.h
@@ -61,6 +61,10 @@ bool serialTaskHandler()
 		}
 	}
 
+#if defined(LED_POWER_PIN)
+	powerControl.update(incomingSize > 0);
+#endif
+
 	return (incomingSize > 0);
 }
 

--- a/include/powercontrol.h
+++ b/include/powercontrol.h
@@ -45,9 +45,9 @@ class
         void init()
         {
             #if defined(LED_POWER_PIN)
-				pinMode(LED_POWER_PIN, OUTPUT);
-				digitalWrite(LED_POWER_PIN, HIGH);
-			#endif
+                pinMode(LED_POWER_PIN, OUTPUT);
+                digitalWrite(LED_POWER_PIN, HIGH);
+            #endif
         }
 
         inline void resetPowerOffTimer()

--- a/include/powercontrol.h
+++ b/include/powercontrol.h
@@ -1,0 +1,95 @@
+/* powercontrol.h
+*
+*  MIT License
+*
+*  Copyright (c) 2023 awawa-dev
+*
+*  https://github.com/awawa-dev/HyperSerialESP32
+*
+*  Permission is hereby granted, free of charge, to any person obtaining a copy
+*  of this software and associated documentation files (the "Software"), to deal
+*  in the Software without restriction, including without limitation the rights
+*  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+*  copies of the Software, and to permit persons to whom the Software is
+*  furnished to do so, subject to the following conditions:
+*
+*  The above copyright notice and this permission notice shall be included in all
+*  copies or substantial portions of the Software.
+
+*  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+*  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+*  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+*  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+*  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+*  SOFTWARE.
+ */
+
+#ifndef POWERCONTROL_H
+#define POWERCONTROL_H
+
+
+/**
+ * @brief Contains logic for turning on and off the power to leds using external relay
+ *
+ */
+class
+{
+    // timeout after which the leds will be turned off if no reset is applied
+	const unsigned long POWER_OFF_PERIOD = 5 * 1000;
+
+	// last timestamp power off timer got reset
+	unsigned long lastPowerOffResetTimestamp = 0;
+
+    public:
+        void init()
+        {
+            #if defined(LED_POWER_PIN)
+				pinMode(LED_POWER_PIN, OUTPUT);
+				digitalWrite(LED_POWER_PIN, HIGH);
+			#endif
+        }
+
+        inline void resetPowerOffTimer()
+        {
+            lastPowerOffResetTimestamp = millis();
+        }
+
+        inline void powerOn()
+        {
+            #if defined(LED_POWER_PIN)
+                digitalWrite(LED_POWER_PIN, HIGH);
+            #endif
+        }
+
+        inline void powerOff()
+        {
+            #if defined(LED_POWER_PIN)
+                digitalWrite(LED_POWER_PIN, LOW);
+            #endif
+        }
+
+        inline void powerToggle()
+        {
+            #if defined(LED_POWER_PIN)
+                auto state = digitalRead(LED_POWER_PIN);
+                digitalWrite(LED_POWER_PIN, (state != LOW) ? LOW : HIGH);              
+            #endif
+        }
+
+        void update(const unsigned long currentTimestamp)
+        {
+            if (currentTimestamp - lastPowerOffResetTimestamp > POWER_OFF_PERIOD)
+            {
+                powerOff();
+            }
+            else
+            {
+                powerOn();
+            }
+        }
+
+} powerControl;
+
+
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -2,7 +2,8 @@
 ; SERIALCOM_SPEED = speed of the serial port (baud), global [env] section
 ; DATA_PIN = pin/GPIO for the LED strip data channel, specific [board] section
 ; CLOCK_PIN = pin/GPIO for the LED strip clock channel, specific [board] section
-;
+; LED_POWER_PIN = pin/GPIO for external power control, will turn of if no serial data is received
+
 ; MULTI-SEGMENT SUPPORT
 ; You can define second segment to handle. Add following parameters (with -D prefix to the build_flags sections).
 ; SECOND_SEGMENT_START_INDEX = start index of the second segment

--- a/platformio.ini
+++ b/platformio.ini
@@ -2,7 +2,7 @@
 ; SERIALCOM_SPEED = speed of the serial port (baud), global [env] section
 ; DATA_PIN = pin/GPIO for the LED strip data channel, specific [board] section
 ; CLOCK_PIN = pin/GPIO for the LED strip clock channel, specific [board] section
-; LED_POWER_PIN = pin/GPIO for external power control, will turn of if no serial data is received
+; LED_POWER_PIN = pin/GPIO for external relay power control, it will turn off (low state) if no serial data is received after 5 seconds
 
 ; MULTI-SEGMENT SUPPORT
 ; You can define second segment to handle. Add following parameters (with -D prefix to the build_flags sections).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,13 +155,15 @@
 	};
 #endif
 
+#define SerialPort Serial
+
 #if defined(LED_POWER_PIN)
 	#pragma message(VAR_NAME_VALUE(LED_POWER_PIN))
+	#include "powercontrol.h"
 #endif
 
-#define SerialPort Serial
 #include "main.h"
-#include "powercontrol.h"
+
 
 /**
  * @brief separete thread for handling incoming data using cyclic buffer
@@ -181,16 +183,8 @@ void processSerialTask(void * parameters)
 {
 	for(;;)
 	{
-		bool receivedData = serialTaskHandler();
-		if (receivedData || base.queueCurrent != base.queueEnd)
+		if (serialTaskHandler() || base.queueCurrent != base.queueEnd)
 			xSemaphoreGive(base.i2sXSemaphore);
-		
-		if(receivedData)
-		{
-			powerControl.resetPowerOffTimer();
-		}
-		powerControl.update(millis());
-
 		yield();
 	}
 }
@@ -282,13 +276,7 @@ void loop()
 {
 	if (base.processDataHandle == nullptr && base.processSerialHandle == nullptr)
 	{
-		bool receivedData = serialTaskHandler();
-
-		if(receivedData)
-		{
-			powerControl.resetPowerOffTimer();
-		}
-
+		serialTaskHandler();
 		processData();
 	}
 }


### PR DESCRIPTION
# Description
This enhancement implementes a mechanism to power off the LED power source using an external pin.
The mechanism is triggered 5 seconds after no serial data is received.

This feature is mainly implemented due to power saving. 60 WS2815 RGB LEDs have an idle power consumption of 0.12A on 12V. Which is ~1.5W of power when they are not in use (only 12V active).

# Tested
* ESP32-WROOM-32
* WS281x_RGB
* HyperHDR 19.0.0.0

# Potential issues
For static color light the refresh rate has to be non zero value. Otherwise no serial data will be transmitted and the LEDs will turn off.

Is this an issue with the configuration as the readme shows a refresh rate of 0?