### PR TITLE
add LED_POWER_INVERT build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Implementation example:
 You can configure LED power pin in the `platformio.ini` to power off LEDs while not in use.
 Review the comments at the top of the file:
 * `LED_POWER_PIN` - This is the data pin external power control
+* `LED_POWER_INVERT` - This inverts the output of the exernal power control pin. If set to `false`, the pin state will be low when the relay is turned off. If set to `true`, the pin state will be high when the relay is off. If not defined, default is `false`.
 
 Note: For static color configuration this mechanism will turn off the LEDs. To counter this enable "Continuous Output" in HyperHDR "Smoothing" module. For esp32 and relay control, you may want to disable the "Handshake" option in the Adalight HyperHDR driver to avoid the relay immediately shutting down when resetting the device while initializing the connection.
 

--- a/include/powercontrol.h
+++ b/include/powercontrol.h
@@ -42,30 +42,30 @@ class
 	volatile unsigned long lastPowerOffResetTimestamp = 0;
 
 	// caching the PIN state to avoid unnecessary calls to the GPIO register
-	volatile int currentPowerPinMode = LOW;
+	volatile int currentPowerPinMode = LED_POWER_INVERT ? LOW : HIGH;
 
 	public:
 		void init()
 		{
 			pinMode(LED_POWER_PIN, OUTPUT);
 			lastPowerOffResetTimestamp = millis();
-			powerOn();
+			powerOff();
 		}
 
 		inline void powerOn()
 		{
-			if (currentPowerPinMode != HIGH)
+			if (currentPowerPinMode != LED_POWER_INVERT ? LOW : HIGH)
 			{
-				currentPowerPinMode = HIGH;
+				currentPowerPinMode = LED_POWER_INVERT ? LOW : HIGH;
 				digitalWrite(LED_POWER_PIN, currentPowerPinMode);
 			}
 		}
 
 		inline void powerOff()
 		{
-			if (currentPowerPinMode != LOW)
+			if (currentPowerPinMode != LED_POWER_INVERT ? HIGH : LOW)
 			{
-				currentPowerPinMode = LOW;
+				currentPowerPinMode = LED_POWER_INVERT ? HIGH : LOW;
 				digitalWrite(LED_POWER_PIN, currentPowerPinMode);
 			}
 		}

--- a/include/powercontrol.h
+++ b/include/powercontrol.h
@@ -28,6 +28,13 @@
 #ifndef POWERCONTROL_H
 #define POWERCONTROL_H
 
+#if LED_POWER_INVERT
+	#define FUNCTION_POWER_ON() powerOff()
+	#define FUNCTION_POWER_OFF() powerOn()
+#else
+	#define FUNCTION_POWER_ON() powerOn()
+	#define FUNCTION_POWER_OFF() powerOff()
+#endif
 
 /**
  * @brief Contains logic for turning on and off the power to leds using external relay
@@ -42,30 +49,30 @@ class
 	volatile unsigned long lastPowerOffResetTimestamp = 0;
 
 	// caching the PIN state to avoid unnecessary calls to the GPIO register
-	volatile int currentPowerPinMode = LED_POWER_INVERT ? HIGH : LOW;
+	volatile int currentPowerPinMode = LED_POWER_INVERT ? LOW : HIGH;
 
 	public:
 		void init()
 		{
 			pinMode(LED_POWER_PIN, OUTPUT);
 			lastPowerOffResetTimestamp = millis();
-			powerOn();
+			powerOff();
 		}
 
-		inline void powerOn()
+		inline void FUNCTION_POWER_ON()
 		{
-			if (currentPowerPinMode != LED_POWER_INVERT ? LOW : HIGH)
+			if (currentPowerPinMode != HIGH)
 			{
-				currentPowerPinMode = LED_POWER_INVERT ? LOW : HIGH;
+				currentPowerPinMode = HIGH;
 				digitalWrite(LED_POWER_PIN, currentPowerPinMode);
 			}
 		}
 
-		inline void powerOff()
+		inline void FUNCTION_POWER_OFF()
 		{
-			if (currentPowerPinMode != LED_POWER_INVERT ? HIGH : LOW)
+			if (currentPowerPinMode != LOW)
 			{
-				currentPowerPinMode = LED_POWER_INVERT ? HIGH : LOW;
+				currentPowerPinMode = LOW;
 				digitalWrite(LED_POWER_PIN, currentPowerPinMode);
 			}
 		}

--- a/include/powercontrol.h
+++ b/include/powercontrol.h
@@ -49,7 +49,7 @@ class
 	volatile unsigned long lastPowerOffResetTimestamp = 0;
 
 	// caching the PIN state to avoid unnecessary calls to the GPIO register
-	volatile int currentPowerPinMode = LED_POWER_INVERT ? LOW : HIGH;
+	volatile int currentPowerPinMode = LOW;
 
 	public:
 		void init()

--- a/include/powercontrol.h
+++ b/include/powercontrol.h
@@ -29,11 +29,11 @@
 #define POWERCONTROL_H
 
 #if LED_POWER_INVERT
-	#define FUNCTION_POWER_ON() powerOff()
-	#define FUNCTION_POWER_OFF() powerOn()
+	#define SET_RELAY_HIGH() powerOff()
+	#define SET_RELAY_LOW() powerOn()
 #else
-	#define FUNCTION_POWER_ON() powerOn()
-	#define FUNCTION_POWER_OFF() powerOff()
+	#define SET_RELAY_HIGH() powerOn()
+	#define SET_RELAY_LOW() powerOff()
 #endif
 
 /**
@@ -59,7 +59,7 @@ class
 			powerOff();
 		}
 
-		inline void FUNCTION_POWER_ON()
+		inline void SET_RELAY_HIGH()
 		{
 			if (currentPowerPinMode != HIGH)
 			{
@@ -68,7 +68,7 @@ class
 			}
 		}
 
-		inline void FUNCTION_POWER_OFF()
+		inline void SET_RELAY_LOW()
 		{
 			if (currentPowerPinMode != LOW)
 			{

--- a/include/powercontrol.h
+++ b/include/powercontrol.h
@@ -42,14 +42,14 @@ class
 	volatile unsigned long lastPowerOffResetTimestamp = 0;
 
 	// caching the PIN state to avoid unnecessary calls to the GPIO register
-	volatile int currentPowerPinMode = LED_POWER_INVERT ? LOW : HIGH;
+	volatile int currentPowerPinMode = LED_POWER_INVERT ? HIGH : LOW;
 
 	public:
 		void init()
 		{
 			pinMode(LED_POWER_PIN, OUTPUT);
 			lastPowerOffResetTimestamp = millis();
-			powerOff();
+			powerOn();
 		}
 
 		inline void powerOn()

--- a/platformio.ini
+++ b/platformio.ini
@@ -26,7 +26,6 @@ default_envs = SK6812_RGBW_COLD, SK6812_RGBW_NEUTRAL, WS281x_RGB, SPI_APA102_SK9
 framework = arduino
 extra_scripts = pre:extra_script.py
 build_flags = -DSERIALCOM_SPEED=2000000
-build_flags = -DSERIALCOM_SPEED=2000000
 
 ;==========================================================
 ; ESP32 board

--- a/platformio.ini
+++ b/platformio.ini
@@ -3,6 +3,7 @@
 ; DATA_PIN = pin/GPIO for the LED strip data channel, specific [board] section
 ; CLOCK_PIN = pin/GPIO for the LED strip clock channel, specific [board] section
 ; LED_POWER_PIN = pin/GPIO for external relay power control, it will turn off (low state) if no serial data is received after 5 seconds
+; LED_POWER_INVERT = if true, off state is a high signal. if false, off state is a low signal. if not defined, will default to false
 
 ; MULTI-SEGMENT SUPPORT
 ; You can define second segment to handle. Add following parameters (with -D prefix to the build_flags sections).
@@ -24,6 +25,7 @@ default_envs = SK6812_RGBW_COLD, SK6812_RGBW_NEUTRAL, WS281x_RGB, SPI_APA102_SK9
 [env]
 framework = arduino
 extra_scripts = pre:extra_script.py
+build_flags = -DSERIALCOM_SPEED=2000000
 build_flags = -DSERIALCOM_SPEED=2000000
 
 ;==========================================================

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,10 +25,7 @@ default_envs = SK6812_RGBW_COLD, SK6812_RGBW_NEUTRAL, WS281x_RGB, SPI_APA102_SK9
 [env]
 framework = arduino
 extra_scripts = pre:extra_script.py
-build_flags =
-    -DSERIALCOM_SPEED=2000000
-    ; -DLED_POWER_PIN=16
-    ; -DLED_POWER_INVERT=true
+build_flags = -DSERIALCOM_SPEED=2000000
 
 ;==========================================================
 ; ESP32 board

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,7 +25,10 @@ default_envs = SK6812_RGBW_COLD, SK6812_RGBW_NEUTRAL, WS281x_RGB, SPI_APA102_SK9
 [env]
 framework = arduino
 extra_scripts = pre:extra_script.py
-build_flags = -DSERIALCOM_SPEED=2000000
+build_flags =
+    -DSERIALCOM_SPEED=2000000
+    ; -DLED_POWER_PIN=16
+    ; -DLED_POWER_INVERT=true
 
 ;==========================================================
 ; ESP32 board

--- a/platformio.ini
+++ b/platformio.ini
@@ -3,7 +3,7 @@
 ; DATA_PIN = pin/GPIO for the LED strip data channel, specific [board] section
 ; CLOCK_PIN = pin/GPIO for the LED strip clock channel, specific [board] section
 ; LED_POWER_PIN = pin/GPIO for external relay power control, it will turn off (low state) if no serial data is received after 5 seconds
-; LED_POWER_INVERT = if true, off state is a high signal. if false, off state is a low signal. if not defined, will default to false
+; LED_POWER_INVERT = if defined: off state is a high signal for the power relay, on state is a low signal
 
 ; MULTI-SEGMENT SUPPORT
 ; You can define second segment to handle. Add following parameters (with -D prefix to the build_flags sections).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -157,10 +157,7 @@
 
 #define SerialPort Serial
 
-#if defined(LED_POWER_PIN)
-	#if !defined(LED_POWER_INVERT)
-		#define LED_POWER_INVERT false
-	#endif
+#ifdef LED_POWER_PIN
 	#pragma message(VAR_NAME_VALUE(LED_POWER_PIN))
 	#pragma message(VAR_NAME_VALUE(LED_POWER_INVERT))
 	#include "powercontrol.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -140,6 +140,9 @@
 	#endif
 	#pragma message(VAR_NAME_VALUE2(LED_DRIVER))
 	#pragma message(VAR_NAME_VALUE(SECOND_SEGMENT_START_INDEX))
+	#ifdef SECOND_SEGMENT_REVERSED
+		#pragma message(VAR_NAME_VALUE(SECOND_SEGMENT_REVERSED))
+	#endif	
 	#pragma message(VAR_NAME_VALUE(SECOND_SEGMENT_DATA_PIN))
 	#ifdef SECOND_SEGMENT_CLOCK_PIN
 		#pragma message(VAR_NAME_VALUE(SECOND_SEGMENT_CLOCK_PIN))
@@ -159,7 +162,9 @@
 
 #ifdef LED_POWER_PIN
 	#pragma message(VAR_NAME_VALUE(LED_POWER_PIN))
-	#pragma message(VAR_NAME_VALUE(LED_POWER_INVERT))
+	#ifdef LED_POWER_INVERT
+		#pragma message(VAR_NAME_VALUE(LED_POWER_INVERT))
+	#endif
 	#include "powercontrol.h"
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -158,9 +158,15 @@
 #define SerialPort Serial
 
 #if defined(LED_POWER_PIN)
+	#if !defined(LED_POWER_INVERT)
+		#define LED_POWER_INVERT false
+	#endif
 	#pragma message(VAR_NAME_VALUE(LED_POWER_PIN))
+	#pragma message(VAR_NAME_VALUE(LED_POWER_INVERT))
 	#include "powercontrol.h"
 #endif
+
+
 
 #include "main.h"
 


### PR DESCRIPTION
My relay board is setup so the relay powers on when the pin state is HIGH, which is reversed from what is hardcoded. This PR adds a LED_POWER_INVERT build option, to invert the relay control to support such boards. If LED_POWER_INVERT is set to true, then the pin state is reversed. If not defined, LED_POWER_INVERT defaults to false (same behavior as before).

I also changed the default power state to be off when the ESP boots, as that seems safer to me to wait to apply power to the LEDs until serial data is received.