### PR TITLE
Add direct 32-bit rendering for RGBW with dithering

### DIFF
--- a/include/calibration.h
+++ b/include/calibration.h
@@ -28,7 +28,7 @@
 #ifdef NEOPIXEL_RGBW
 	typedef RgbwColor ColorDefinition;
 #elif defined(SPILED_APA102)
-	typedef DotStarColor ColorDefinition;	
+	typedef RgbwColor ColorDefinition;	
 #else
 	typedef RgbColor ColorDefinition;
 #endif

--- a/include/calibration.h
+++ b/include/calibration.h
@@ -27,6 +27,8 @@
 
 #ifdef NEOPIXEL_RGBW
 	typedef RgbwColor ColorDefinition;
+#elif defined(SPILED_APA102)
+	typedef DotStarColor ColorDefinition;	
 #else
 	typedef RgbColor ColorDefinition;
 #endif

--- a/include/framestate.h
+++ b/include/framestate.h
@@ -35,6 +35,7 @@
 enum class AwaProtocol
 {
 	HEADER_A,
+	HEADER_W,	
 	HEADER_w,
 	HEADER_a,
 	HEADER_HI,
@@ -47,6 +48,7 @@ enum class AwaProtocol
 	RED,
 	GREEN,
 	BLUE,
+	EXTRA_COLOR_BYTE_4,	
 	FLETCHER1,
 	FLETCHER2,
 	FLETCHER_EXT
@@ -60,6 +62,7 @@ class
 {
 	volatile AwaProtocol state = AwaProtocol::HEADER_A;
 	bool protocolVersion2 = false;
+	bool protocolVersion3 = false;	
 	uint8_t CRC = 0;
 	uint16_t count = 0;
 	uint16_t currentLed = 0;
@@ -156,6 +159,27 @@ class
 		inline void setProtocolVersion2(bool newVer)
 		{
 			protocolVersion2 = newVer;
+		}
+
+		/**
+		 * @brief Set if frame protocol version 3 (direct 32bit mode)
+		 *
+		 * @param newVer
+		 */
+		inline void setProtocolVersion3(bool newVer)
+		{
+			protocolVersion3 = newVer;
+		}
+
+		/**
+		 * @brief Verify if frame protocol version 3 (direct 32bit mode)
+		 *
+		 * @return true
+		 * @return false
+		 */
+		inline bool isProtocolVersion3() const
+		{
+			return protocolVersion3;
 		}
 
 		/**

--- a/include/main.h
+++ b/include/main.h
@@ -215,7 +215,7 @@ void processData()
 			#ifdef NEOPIXEL_RGBW
 				frameState.color.W = input;
 			#elif defined(SPILED_APA102)
-				frameState.color.Brightness = input;
+				frameState.color.W = input;
 			#endif
 			frameState.addFletcher(input);
 
@@ -240,7 +240,7 @@ void processData()
 			}
 
 			#if defined(SPILED_APA102)
-				frameState.color.Brightness = 0xFF;
+				frameState.color.W = 0xFF;
 			#endif
 
 			#ifdef NEOPIXEL_RGBW

--- a/include/main.h
+++ b/include/main.h
@@ -29,7 +29,7 @@
 #define MAIN_H
 
 #define MAX_BUFFER (3013 * 3 + 1)
-#define HELLO_MESSAGE "\r\nWelcome!\r\nAwa driver 9."
+#define HELLO_MESSAGE "\r\nWelcome!\r\nAwa driver 11."
 
 #include "calibration.h"
 #include "statistics.h"
@@ -113,6 +113,7 @@ void processData()
 		case AwaProtocol::HEADER_A:
 			// assume it's protocol version 1, verify it later
 			frameState.setProtocolVersion2(false);
+			frameState.setProtocolVersion3(false);
 			if (input == 'A')
 				frameState.setState(AwaProtocol::HEADER_w);
 			break;
@@ -120,6 +121,20 @@ void processData()
 		case AwaProtocol::HEADER_w:
 			if (input == 'w')
 				frameState.setState(AwaProtocol::HEADER_a);
+#if defined(NEOPIXEL_RGBW) || defined(SPILED_APA102)
+			else if (input == 'W')
+				frameState.setState(AwaProtocol::HEADER_W);
+#endif
+			else
+				frameState.setState(AwaProtocol::HEADER_A);
+			break;
+		case AwaProtocol::HEADER_W:
+			// detect protocol version 3
+			if (input == 'a')			
+			{
+				frameState.setState(AwaProtocol::HEADER_HI);
+				frameState.setProtocolVersion3(true);
+			}
 			else
 				frameState.setState(AwaProtocol::HEADER_A);
 			break;
@@ -196,9 +211,37 @@ void processData()
 			frameState.setState(AwaProtocol::BLUE);
 			break;
 
+		case AwaProtocol::EXTRA_COLOR_BYTE_4:
+			#ifdef NEOPIXEL_RGBW
+				frameState.color.W = input;
+			#elif defined(SPILED_APA102)
+				frameState.color.Brightness = input;
+			#endif
+			frameState.addFletcher(input);
+
+			if (base.setStripPixel(frameState.getCurrentLedIndex(), frameState.color))
+			{
+				frameState.setState(AwaProtocol::RED);
+			}
+			else
+			{
+				frameState.setState(AwaProtocol::FLETCHER1);
+			}
+			break;
+
 		case AwaProtocol::BLUE:
 			frameState.color.B = input;
 			frameState.addFletcher(input);
+
+			if (frameState.isProtocolVersion3())
+			{
+				frameState.setState(AwaProtocol::EXTRA_COLOR_BYTE_4);
+				break;
+			}
+
+			#if defined(SPILED_APA102)
+				frameState.color.Brightness = 0xFF;
+			#endif
 
 			#ifdef NEOPIXEL_RGBW
 				// calculate RGBW from RGB using provided calibration data

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,7 +74,7 @@
 #endif
 
 #ifdef SPILED_APA102
-	#define LED_DRIVER NeoPixelBus<DotStarBgrFeature, DotStarEsp32DmaHspiMethod>
+	#define LED_DRIVER NeoPixelBus<DotStarLbgrFeature, DotStarEsp32DmaHspiMethod>
 #elif SPILED_WS2801
 	#define LED_DRIVER NeoPixelBus<NeoRbgFeature, NeoWs2801Spi2MhzMethod>
 #endif
@@ -111,7 +111,7 @@
 				#define LED_DRIVER2 NeoPixelBus<NeoGrbFeature, NeoEsp32I2s0Ws2812xMethod>
 			#endif
 		#elif SPILED_APA102
-			#define LED_DRIVER2 NeoPixelBus<DotStarBgrFeature, DotStarEsp32DmaHspiMethod>
+			#define LED_DRIVER2 NeoPixelBus<DotStarLbgrFeature, DotStarEsp32DmaHspiMethod>
 		#elif SPILED_WS2801
 			#define LED_DRIVER2 NeoPixelBus<NeoRbgFeature, NeoWs2801Spi2MhzMethod>
 		#endif
@@ -133,7 +133,7 @@
 				#define LED_DRIVER2 NeoPixelBus<NeoGrbFeature, NeoEsp32I2s0Ws2812xMethod>
 			#endif
 		#elif SPILED_APA102
-			#define LED_DRIVER2 NeoPixelBus<DotStarBgrFeature, DotStarEsp32DmaVspiMethod>
+			#define LED_DRIVER2 NeoPixelBus<DotStarLbgrFeature, DotStarEsp32DmaVspiMethod>
 		#elif SPILED_WS2801
 			#define LED_DRIVER2 NeoPixelBus<NeoRbgFeature, NeoWs2801Spi2MhzMethod>
 		#endif


### PR DESCRIPTION
Introduced direct 32-bit mode for the upcoming RGBW mode with dithering, powered by the Infinite Color Engine in HyperHDR.
More: https://github.com/awawa-dev/HyperHDR/wiki/ICE_RGBW