### PR TITLE
Fix ESP32-S2 USB CDC boot

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -87,9 +87,14 @@ test_ignore = ${esp32.test_ignore}
 platform = espressif32@6.0.0
 lib_deps = https://github.com/awawa-dev/NeoPixelBus.git#HyperSerialESP32
 test_ignore = *
+build_flags =
+	-DARDUINO_USB_MODE=0
+	-DARDUINO_USB_CDC_ON_BOOT=1
+	-DARDUINO_USB_MSC_ON_BOOT=0
+	-DARDUINO_USB_DFU_ON_BOOT=0
 
 [env:s2_mini_SK6812_RGBW_COLD]
-build_flags = -DNEOPIXEL_RGBW -DCOLD_WHITE -DDATA_PIN=2 ${env.build_flags}
+build_flags = -DNEOPIXEL_RGBW -DCOLD_WHITE -DDATA_PIN=2 ${esp32_lolin_s2_mini.build_flags} ${env.build_flags}
 custom_prog_version = esp32_s2_mini_SK6812_RGBW_COLD
 
 board = lolin_s2_mini
@@ -99,7 +104,7 @@ lib_deps = ${esp32_lolin_s2_mini.lib_deps}
 test_ignore = ${esp32_lolin_s2_mini.test_ignore}
 
 [env:s2_mini_SK6812_RGBW_NEUTRAL]
-build_flags = -DNEOPIXEL_RGBW -DDATA_PIN=2 ${env.build_flags}
+build_flags = -DNEOPIXEL_RGBW -DDATA_PIN=2 ${esp32_lolin_s2_mini.build_flags} ${env.build_flags}
 custom_prog_version = esp32_s2_mini_SK6812_RGBW_NEUTRAL
 
 board = lolin_s2_mini
@@ -109,7 +114,7 @@ lib_deps = ${esp32_lolin_s2_mini.lib_deps}
 test_ignore = ${esp32_lolin_s2_mini.test_ignore}
 
 [env:s2_mini_WS281x_RGB]
-build_flags = -DNEOPIXEL_RGB -DDATA_PIN=2 ${env.build_flags}
+build_flags = -DNEOPIXEL_RGB -DDATA_PIN=2 ${esp32_lolin_s2_mini.build_flags} ${env.build_flags}
 custom_prog_version = esp32_s2_mini_WS281x_RGB
 
 board = lolin_s2_mini
@@ -119,7 +124,7 @@ lib_deps = ${esp32_lolin_s2_mini.lib_deps}
 test_ignore = ${esp32_lolin_s2_mini.test_ignore}
 
 [env:s2_mini_SPI_APA102_SK9822_HD107]
-build_flags = -DSPILED_APA102 -DDATA_PIN=2 -DCLOCK_PIN=4 ${env.build_flags}
+build_flags = -DSPILED_APA102 -DDATA_PIN=2 -DCLOCK_PIN=4 ${esp32_lolin_s2_mini.build_flags} ${env.build_flags}
 custom_prog_version = esp32_s2_mini_SPI_APA102_SK9822_HD107
 
 board = lolin_s2_mini
@@ -129,7 +134,7 @@ lib_deps = ${esp32_lolin_s2_mini.lib_deps}
 test_ignore = ${esp32_lolin_s2_mini.test_ignore}
 
 [env:s2_mini_SPI_WS2801]
-build_flags = -DSPILED_WS2801 -DDATA_PIN=2 -DCLOCK_PIN=4 ${env.build_flags}
+build_flags = -DSPILED_WS2801 -DDATA_PIN=2 -DCLOCK_PIN=4 ${esp32_lolin_s2_mini.build_flags} ${env.build_flags}
 custom_prog_version = esp32_s2_mini_SPI_WS2801
 
 board = lolin_s2_mini
@@ -137,4 +142,3 @@ board_build.mcu = esp32s2
 platform = ${esp32_lolin_s2_mini.platform}
 lib_deps = ${esp32_lolin_s2_mini.lib_deps}
 test_ignore = ${esp32_lolin_s2_mini.test_ignore}
-

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -205,7 +205,13 @@ void setup()
 	Serial.setRxBufferSize(MAX_BUFFER - 1);
 	Serial.setTimeout(50);
 	Serial.begin(SERIALCOM_SPEED);
-	while (!Serial) continue;
+	#if defined(CONFIG_IDF_TARGET_ESP32S2)
+		// Headless USB CDC hosts won't open an interactive serial monitor.
+		// Waiting forever here can stall S2 startup before the CDC port is usable.
+		delay(50);
+	#else
+		while (!Serial) continue;
+	#endif
 
 	#if defined(NEOPIXEL_RGBW) || defined(NEOPIXEL_RGB)
 		#ifdef NEOPIXEL_RGBW
@@ -288,4 +294,3 @@ void loop()
 		processData();
 	}
 }
-


### PR DESCRIPTION
## Summary
- make ESP32-S2 LOLIN S2 Mini USB flags explicit instead of relying on implicit board defaults
- avoid blocking forever on `while (!Serial)` for ESP32-S2 native USB CDC boot
- keep non-S2 behavior unchanged

## Why
`v11.0.0` flashed successfully for `s2_mini_WS281x_RGB` but failed to enumerate as a USB CDC device on both macOS and an LG webOS host in headless use. The same hardware worked again after downgrading to `v9.0.0.0`.

This change hardens the S2 boot path in two places:
- explicitly sets `ARDUINO_USB_MODE=0` and `ARDUINO_USB_CDC_ON_BOOT=1` for `lolin_s2_mini` envs
- removes the infinite wait on `Serial` readiness for ESP32-S2, which is fragile on native USB CDC hosts that do not open an interactive serial monitor

## Verification
- built locally with `pio run -e s2_mini_WS281x_RGB`
